### PR TITLE
Docker python improvements

### DIFF
--- a/showbuddy-python/.dockerignore
+++ b/showbuddy-python/.dockerignore
@@ -5,3 +5,4 @@
 *.pyc
 __pycache__
 .coverage
+showbuddy-data

--- a/showbuddy-python/Dockerfile
+++ b/showbuddy-python/Dockerfile
@@ -1,11 +1,18 @@
-FROM python:3.13.3-alpine
+FROM python:3.13.3-alpine AS builder
 
 WORKDIR /app
-EXPOSE 8000
-RUN python3 -m pip install --upgrade pip
-RUN python3 -m pip install uv
-COPY uv.lock /app/uv.lock
-COPY  pyproject.toml /app/pyproject.toml
+
+RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install uv
+
+COPY uv.lock pyproject.toml ./
 RUN uv sync
+
+FROM python:3.13.3-alpine AS runtime
+
+EXPOSE 8000
+WORKDIR /app
+COPY --from=builder /app/.venv /app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
 COPY . .
 ENTRYPOINT [ "./entrypoint.sh" ]

--- a/showbuddy-python/Dockerfile
+++ b/showbuddy-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.3
+FROM python:3.13.3-alpine
 
 WORKDIR /app
 EXPOSE 8000

--- a/showbuddy-python/entrypoint.sh
+++ b/showbuddy-python/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec uv run uvicorn --factory 'web:make_web_app' --host 0.0.0.0 --port 8000
+exec uvicorn --factory 'web:make_web_app' --host 0.0.0.0 --port 8000

--- a/showbuddy-python/entrypoint.sh
+++ b/showbuddy-python/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-uv run uvicorn --factory 'web:make_web_app' --host 0.0.0.0 --port 8000
+exec uv run uvicorn --factory 'web:make_web_app' --host 0.0.0.0 --port 8000


### PR DESCRIPTION
Use python:3.13.3-alpine image to reduce image size
Multi-stage Docker build to reduce image down below 60MB